### PR TITLE
Wengert/v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 03-20-2020
+
+### Added
+- Ability to pass in a build `target` to the buildTheme function.
+- `core.LineHeight` accepts the `web` target to add the `px` definition.
+- `InputPaddingTop`
+- `InputPaddingRight`
+- `InputPaddingBottom`
+- `InputPaddingLeft`
+- `InputLabelPaddingLeft`
+- `InputLabelPaddingRight`
+
+### Changed
+- `core.Time.*` is now an int without the `ms`.
+
+### Removed
+- Removed `core.BorderRadius.Rounded` as a circle is created completely differently across the different platforms.
+- Removed `InputPadding` in favor of individually specified tokens.
+- Removed `InputLabelPadding` in favor of individually specified tokens.
+
+
 ## [4.1.0] - 03-16-2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.0] - 03-20-2020
 
 ### Added
+- `core.Resolution` exports the int version of `core.MediaQuery`.
 - Ability to pass in a build `target` to the buildTheme function.
-- `core.LineHeight` accepts the `web` target to add the `px` definition.
+- Exports `targets` const for use in other repos.
+- `core.LineHeight` accepts the `REACT` target to add the `px` definition.
+- `core.BoxShadow` accepts `target` with the current focus being `REACT`. Exploration still required.
+- `core.Easing` accepts `target`. Still exploring non web solutions.
 - `InputPaddingTop`
 - `InputPaddingRight`
 - `InputPaddingBottom`
@@ -17,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InputLabelPaddingRight`
 
 ### Changed
+- Argument order of `buildTheme`.
 - `core.Time.*` is now an int without the `ms`.
+- `core.MediaQuery.*` includes `px` as it's implied web values.
 
 ### Removed
 - Removed `core.BorderRadius.Rounded` as a circle is created completely differently across the different platforms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-design-tokens",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-design-tokens",
-  "version": "2.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-design-tokens",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Design Tokens",
   "main": "dist/index.js",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,13 @@ import fontSize from 'src/tokens/fontSize'
 import spacing from 'src/tokens/spacing'
 import textColor from 'src/tokens/textColor'
 
-export const buildTheme = (themeName, customColors={}, target) => {
+export const targets = {
+  REACT: 'react',
+  REACT_NATIVE: 'react_native',
+  NATIVE: 'native',
+}
+
+export const buildTheme = (themeName, target=targets.REACT, customColors={}) => {
   const customCore = {
     ...core,
     Color: {
@@ -19,7 +25,6 @@ export const buildTheme = (themeName, customColors={}, target) => {
   const builtCore = {}
 
   Object.keys(customCore).forEach(coreKey => {
-
     const value = typeof customCore[coreKey] === 'function' ?
       customCore[coreKey](target) :
       customCore[coreKey]

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import fontSize from 'src/tokens/fontSize'
 import spacing from 'src/tokens/spacing'
 import textColor from 'src/tokens/textColor'
 
-export const buildTheme = (themeName, customColors={}) => {
+export const buildTheme = (themeName, customColors={}, target) => {
   const customCore = {
     ...core,
     Color: {
@@ -16,27 +16,39 @@ export const buildTheme = (themeName, customColors={}) => {
     },
   }
 
+  const builtCore = {}
+
+  Object.keys(customCore).forEach(coreKey => {
+
+    const value = typeof customCore[coreKey] === 'function' ?
+      customCore[coreKey](target) :
+      customCore[coreKey]
+
+    builtCore[coreKey] = value
+  })
+
+
   return {
-    ...customCore,
-    BackgroundColor: backgroundColor[themeName](customCore),
-    BorderColor: borderColor[themeName](customCore),
+    ...builtCore,
+    BackgroundColor: backgroundColor[themeName](builtCore),
+    BorderColor: borderColor[themeName](builtCore),
     BorderRadius: {
       ...core.BorderRadius,
-      ...borderRadius[themeName](customCore),
+      ...borderRadius[themeName](builtCore),
     },
     BoxShadow: {
       ...core.BoxShadow,
-      ...boxShadow[themeName](customCore),
+      ...boxShadow[themeName](builtCore),
     },
     FontSize: {
       ...core.FontSize,
-      ...fontSize[themeName](customCore),
+      ...fontSize[themeName](builtCore),
     },
     Spacing: {
       ...core.Spacing,
-      ...spacing[themeName](customCore),
+      ...spacing[themeName](builtCore),
     },
-    TextColor: textColor[themeName](customCore),
+    TextColor: textColor[themeName](builtCore),
   }
 }
 

--- a/src/tokens/core.js
+++ b/src/tokens/core.js
@@ -62,7 +62,7 @@ export default {
     H1: 32,
   },
   FontWeight: {
-   Regular: 400,
+    Regular: 400,
     Semibold: 600,
     Bold: 700,
   },

--- a/src/tokens/core.js
+++ b/src/tokens/core.js
@@ -9,7 +9,7 @@ export default {
     NeutralWhite: "#FFFFFF",
     Neutral100: "#F8F9FB",
     Neutral200: "#EEF1F6",
-    Neutral300: "#E4E8EE", 
+    Neutral300: "#E4E8EE",
     Neutral400: "#CDD3DD",
     Neutral500: "#A8B1BD",
     Neutral600: "#6A7381",
@@ -49,7 +49,6 @@ export default {
     Small: 2,
     Medium: 4,
     Large: 16,
-    Rounded: `50%`,
   },
   FontSize: {
     Tiny: 10,
@@ -63,20 +62,33 @@ export default {
     H1: 32,
   },
   FontWeight: {
-    Regular: 400,
+   Regular: 400,
     Semibold: 600,
     Bold: 700,
   },
-  LineHeight: {
-    Tiny: 12,
-    XSmall: 14,
-    Small: 16,
-    ParagraphSmall: 20,
-    Body: 20,
-    Paragraph: 24,
-    H3: 24,
-    H2: 32,
-    H1: 40,
+  LineHeight: target => {
+    const base = {
+      Tiny: 12,
+      XSmall: 14,
+      Small: 16,
+      ParagraphSmall: 20,
+      Body: 20,
+      Paragraph: 24,
+      H3: 24,
+      H2: 32,
+      H1: 40,
+    }
+
+    if (target === 'web') {
+      const web = {}
+
+      Object.keys(base).forEach(key => {
+        web[key] = `${base[key]}px`
+      })
+      return web
+    }
+
+    return base
   },
   Spacing: {
     Tiny: 4,
@@ -91,9 +103,9 @@ export default {
     SuperJumbo: 96,
   },
   Time: {
-    Short: "300ms",
-    Med: "500ms",
-    Long: "1000ms"
+    Short: 300,
+    Med: 500,
+    Long: 1000,
   },
   Easing: {
     Default: "cubic-bezier(.475,.425,0,.995)"

--- a/src/tokens/core.js
+++ b/src/tokens/core.js
@@ -1,4 +1,16 @@
-// This should not be modified
+import { targets } from '../index'
+// This should probably not be modified
+
+const addPx = obj => {
+  const newObj = {}
+
+  Object.keys(obj).forEach(key => {
+    newObj[key] = `${obj[key]}px`
+  })
+
+  return newObj
+}
+
 export default {
   Color: {
     Primary100: "#EAF1FB",
@@ -36,14 +48,29 @@ export default {
     TransparentScrim: "rgba(0, 0, 0, 0.25)",
     TransparentScrimDarker: "rgba(0, 0, 0, 0.50)",
   },
-  BoxShadow: {
-    Low: ' 0px 1px 3px rgba(87, 102, 117, 0.2)',
-    Medium: ' 0px 3px 8px rgba(87, 102, 117, 0.15)',
-    High: ' 0px 10px 20px rgba(87, 102, 117, 0.16)',
-    Top: ' 0px -1px 3px rgba(87, 102, 117, 0.2)',
-    Left: ' -1px 0px 3px rgba(87, 102, 117, 0.2)',
-    Right: ' 1px 0px 3px rgba(87, 102, 117, 0.2)',
-    Focus: '0px 0px 0px 2px rgba(82, 138, 224, 0.8)',
+  BoxShadow: target => {
+    if (target === targets.REACT) {
+      return {
+        Low: ' 0px 1px 3px rgba(87, 102, 117, 0.2)',
+        Medium: ' 0px 3px 8px rgba(87, 102, 117, 0.15)',
+        High: ' 0px 10px 20px rgba(87, 102, 117, 0.16)',
+        Top: ' 0px -1px 3px rgba(87, 102, 117, 0.2)',
+        Left: ' -1px 0px 3px rgba(87, 102, 117, 0.2)',
+        Right: ' 1px 0px 3px rgba(87, 102, 117, 0.2)',
+        Focus: '0px 0px 0px 2px rgba(82, 138, 224, 0.8)',
+      }
+    }
+
+    // TODO: explore mobile solutions more
+    return {
+      Low: '',
+      Medium: '',
+      High: '',
+      Top: '',
+      Left: ''
+      Right: '',
+      Focus: ''
+    }
   },
   BorderRadius: {
     Small: 2,
@@ -79,13 +106,8 @@ export default {
       H1: 40,
     }
 
-    if (target === 'web') {
-      const web = {}
-
-      Object.keys(base).forEach(key => {
-        web[key] = `${base[key]}px`
-      })
-      return web
+    if (target === targets.REACT) {
+      return addPx(base)
     }
 
     return base
@@ -107,10 +129,31 @@ export default {
     Med: 500,
     Long: 1000,
   },
-  Easing: {
-    Default: "cubic-bezier(.475,.425,0,.995)"
+  Easing: target => {
+    if (target === targets.REACT) {
+      return {
+        Default: "cubic-bezier(.475,.425,0,.995)"
+      }
+    }
+
+    // TODO: Define type cubic-bezier?
+    return {
+      Default: {
+        x1: 0.475,
+        y1: 0.425,
+        x2: 0,
+        y2: 0.995
+      }
+    }
   },
+  // Convenience values as web consumes both constantly
   MediaQuery: {
+    Small: '576px',
+    Med: '768px',
+    Large: '992px',
+    XLarge: '1200px',
+  },
+  Resolution: {
     Small: 576,
     Med: 768,
     Large: 992,

--- a/src/tokens/core.js
+++ b/src/tokens/core.js
@@ -67,7 +67,7 @@ export default {
       Medium: '',
       High: '',
       Top: '',
-      Left: ''
+      Left: '',
       Right: '',
       Focus: ''
     }

--- a/src/tokens/spacing.js
+++ b/src/tokens/spacing.js
@@ -1,21 +1,35 @@
 const light = core => ({
+  // Button
   ButtonPadding: core.Spacing.Small,
+  // Card
+  CardSidePadding: core.Spacing.Medium,
+  // Checkbox
   CheckboxLabelMarginLeft: core.Spacing.Small,
   CheckboxLabelMarginRight: core.Spacing.Small,
-  SwitchLabelMarginLeft: core.Spacing.Small,
-  SwitchLabelMarginRight: core.Spacing.Small,
-  InputLabelTop: `-${core.Spacing.XSmall}`,
-  InputLabelMarginLeft: core.Spacing.Small,
-  InputLabelPadding: `0 ${core.Spacing.Tiny}`,
-  InputPadding: `${core.Spacing.Medium} ${core.Spacing.Small} ${core.Spacing.Small} ${core.Spacing.Small}`,
-  InputHelpTextMarginTop: core.Spacing.Tiny,
-  TextAreaPadding: core.Spacing.Small,
+  // Container
+  ContainerSidePadding: core.Spacing.Large,
+  // Dropdown
   DropdownToggle: core.Spacing.Small,
   DropdownItemPaddingTopBottom: core.Spacing.Small,
-  DropdownItemPaddingLeftright: core.Spacing.XSmall,
+  DropdownItemPaddingLeftRight: core.Spacing.XSmall,
+  // Input
+  InputLabelTop: -Math.abs(core.Spacing.XSmall),
+  InputLabelMarginLeft: core.Spacing.Small,
+  InputLabelPaddingLeft: core.Spacing.Tiny,
+  InputLabelPaddingRight: core.Spacing.Tiny,
+  InputPaddingTop: core.Spacing.Medium,
+  InputPaddingRight: core.Spacing.Small,
+  InputPaddingBottom: core.Spacing.Small,
+  InputPaddingLeft: core.Spacing.Small,
+  InputHelpTextMarginTop: core.Spacing.Tiny,
+  // Modal
   ModalPadding: core.Spacing.Small,
-  ContainerSidePadding: core.Spacing.Large,
-  CardSidePadding: core.Spacing.Medium,
+  // Switch
+  SwitchLabelMarginLeft: core.Spacing.Small,
+  SwitchLabelMarginRight: core.Spacing.Small,
+  // TextArea
+  TextAreaPadding: core.Spacing.Small,
+  // Tooltip
   TooltipPadding: core.Spacing.Small,
 })
 


### PR DESCRIPTION
Version 5.0.0

Copy from the changelog

## [5.0.0] - 03-20-2020

### Added
- Ability to pass in a build `target` to the buildTheme function.
- `core.LineHeight` accepts the `web` target to add the `px` definition.
- `InputPaddingTop`
- `InputPaddingRight`
- `InputPaddingBottom`
- `InputPaddingLeft`
- `InputLabelPaddingLeft`
- `InputLabelPaddingRight`

### Changed
- `core.Time.*` is now an int without the `ms`.

### Removed
- Removed `core.BorderRadius.Rounded` as a circle is created completely differently across the different platforms.
- Removed `InputPadding` in favor of individually specified tokens.
- Removed `InputLabelPadding` in favor of individually specified tokens.

Also exploring organizing tokens by component comments. @brianrclay 