### PR TITLE
fixed chip border radius

### DIFF
--- a/src/tokens/borderRadius.js
+++ b/src/tokens/borderRadius.js
@@ -7,7 +7,7 @@ const light = core => ({
   // Checkbox
   Checkbox: core.BorderRadius.Small,
   // Chip
-  Chip: core.BorderRadius.Small,
+  Chip: 12,
   // Container
   Container: core.BorderRadius.Medium,
   // Dropdown


### PR DESCRIPTION
There isn't a border radius of `12px` available in the core border radius tokens, so I just hard coded the value. 