### PR TITLE
Swap `px` for `ms` in Time token values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [9.0.1] - 05-27-2021
+## [9.0.1] - 05-28-2021
 
 ### Fixed
 
-- The `Time` token was incorrectly appending `px` for `.css` and `.scss` output
+- The `Time` token values now append `ms` instead of `px` for `.css` and `.scss` output
 
 ## [9.0.0] - 05-27-2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [9.0.1] - 05-27-2021
+
+### Fixed
+
+- The `Time` token was incorrectly appending `px` for `.css` and `.scss` output
+
 ## [9.0.0] - 05-27-2021
 
 ### Added

--- a/bin/css.js
+++ b/bin/css.js
@@ -15,17 +15,41 @@ function getCssContent(json, theme) {
   const keys = Object.keys(json)
 
   const formatValue = (val, token) => {
-    let retVal = val
-
-    if (token === 'Font') {
-      retVal = `(${val})`
-    } else if (token === 'FontWeight') {
-      retVal = val
-    } else if (Number.isInteger(val)) {
-      retVal = `${val}px`
+    // explicitly define any decorators which should appear before or after each value of various tokens
+    const tokenDecorators = {
+      BorderRadius: {
+        pre: '',
+        post: 'px',
+      },
+      Font: {
+        pre: '(',
+        post: ')',
+      },
+      FontSize: {
+        pre: '',
+        post: 'px',
+      },
+      Resolution: {
+        pre: '',
+        post: 'px',
+      },
+      Spacing: {
+        pre: '',
+        post: 'px',
+      },
     }
 
-    return retVal
+    const td = { pre: '', post: '', skip: [], ...tokenDecorators[token] }
+
+    let isExcluded = false
+
+    for (let i = 0; i < td.skip.length; i++) {
+      if (td.skip[i] === val) {
+        isExcluded = true
+      }
+    }
+
+    return isExcluded ? val : td.pre + val + td.post
   }
 
   keys.forEach((key) => {
@@ -33,7 +57,7 @@ function getCssContent(json, theme) {
     let baseKey = `--mx-${key}`
 
     Object.keys(json[key]).forEach((childKey) => {
-      const value = formatValue(json[key][childKey], key)
+      const value = json[key][childKey] ? formatValue(json[key][childKey], key) : null
 
       if (value) {
         css += `  ${baseKey}_${childKey}: ${value};\n`

--- a/bin/css.js
+++ b/bin/css.js
@@ -33,6 +33,9 @@ function getCssContent(json, theme) {
       Spacing: {
         post: 'px',
       },
+      Time: {
+        post: 'ms',
+      },
     }
 
     const td = { pre: '', post: '', skip: [], ...tokenDecorators[token] }

--- a/bin/css.js
+++ b/bin/css.js
@@ -18,7 +18,6 @@ function getCssContent(json, theme) {
     // explicitly define any decorators which should appear before or after each value of various tokens
     const tokenDecorators = {
       BorderRadius: {
-        pre: '',
         post: 'px',
       },
       Font: {
@@ -26,15 +25,12 @@ function getCssContent(json, theme) {
         post: ')',
       },
       FontSize: {
-        pre: '',
         post: 'px',
       },
       Resolution: {
-        pre: '',
         post: 'px',
       },
       Spacing: {
-        pre: '',
         post: 'px',
       },
     }

--- a/bin/docs.js
+++ b/bin/docs.js
@@ -26,7 +26,7 @@ function getDocsContent(themeName) {
   const json = t.themeList[themeName]
   const keys = Object.keys(json)
 
-  let md = `![${themeName} theme](./header_${themeName}.png)\n\n---\n\n`
+  let md = `![${themeName} theme](./header_${themeName}.png)\n\n`
 
   keys.forEach((key) => {
     md += `### ${key} &nbsp; <sub><sup>( _${themeName}_ )</sup></sub>\n\n`

--- a/bin/scss.js
+++ b/bin/scss.js
@@ -16,7 +16,6 @@ function getSassContent(json, theme) {
     // explicitly define any decorators which should appear before or after each value of various tokens
     const tokenDecorators = {
       BorderRadius: {
-        pre: '',
         post: 'px',
       },
       BoxShadow: {
@@ -29,15 +28,12 @@ function getSassContent(json, theme) {
         post: ')',
       },
       FontSize: {
-        pre: '',
         post: 'px',
       },
       Resolution: {
-        pre: '',
         post: 'px',
       },
       Spacing: {
-        pre: '',
         post: 'px',
       },
     }

--- a/bin/scss.js
+++ b/bin/scss.js
@@ -36,6 +36,9 @@ function getSassContent(json, theme) {
       Spacing: {
         post: 'px',
       },
+      Time: {
+        post: 'ms',
+      },
     }
 
     const td = { pre: '', post: '', skip: [], ...tokenDecorators[token] }

--- a/bin/scss.js
+++ b/bin/scss.js
@@ -12,25 +12,47 @@ t.themes.forEach((themeObj) =>
 function getSassContent(json, theme) {
   let sass = pkg.getHeaderComment(`/scss/${theme}.scss`, 'sass variables', pkg.getTimestamp())
   const keys = Object.keys(json)
-
   const formatValue = (val, token) => {
-    let retVal = val
+    // explicitly define any decorators which should appear before or after each value of various tokens
+    const tokenDecorators = {
+      BorderRadius: {
+        pre: '',
+        post: 'px',
+      },
+      BoxShadow: {
+        pre: '"',
+        post: '"',
+        skip: ['none'],
+      },
+      Font: {
+        pre: '(',
+        post: ')',
+      },
+      FontSize: {
+        pre: '',
+        post: 'px',
+      },
+      Resolution: {
+        pre: '',
+        post: 'px',
+      },
+      Spacing: {
+        pre: '',
+        post: 'px',
+      },
+    }
 
-    if (token === 'Font') {
-      retVal = `(${val})`
-    } else if (token === 'FontWeight') {
-      retVal = val
-    } else if (Number.isInteger(val)) {
-      retVal = `${val}px`
-    } else if (token === 'BoxShadow') {
-      let v = val.trim()
+    const td = { pre: '', post: '', skip: [], ...tokenDecorators[token] }
 
-      if (v && v !== 'none') {
-        retVal = `"${v}"`
+    let isExcluded = false
+
+    for (let i = 0; i < td.skip.length; i++) {
+      if (td.skip[i] === val) {
+        isExcluded = true
       }
     }
 
-    return retVal
+    return isExcluded ? val : td.pre + val + td.post
   }
 
   for (let i = 0; i < keys.length; i++) {
@@ -42,7 +64,7 @@ function getSassContent(json, theme) {
 
     for (let j = 0; j < props.length; j++) {
       const p = props[j]
-      const v = formatValue(values[p], k)
+      const v = values[p] ? formatValue(values[p], k) : null
 
       if (v) {
         sass += `  "${p}": ${v},\n`

--- a/css/dark.css
+++ b/css/dark.css
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (9.0.1)
 **
-** css variables auto-generated on 2021-05-27
+** css variables auto-generated on 2021-05-28
 ** from https://github.com/mxenabled/mx-design-tokens to /css/dark.css
 */
 :root {

--- a/css/dark.css
+++ b/css/dark.css
@@ -1,5 +1,5 @@
 /*
-** mx-design-tokens (9.0.0)
+** mx-design-tokens (9.0.1)
 **
 ** css variables auto-generated on 2021-05-27
 ** from https://github.com/mxenabled/mx-design-tokens to /css/dark.css
@@ -166,9 +166,9 @@
   --mx-Spacing_TagSmallPaddingLeftRight: 8px;
   --mx-Spacing_TextAreaPadding: 12px;
   --mx-Spacing_TooltipPadding: 12px;
-  --mx-Time_Short: 300px;
-  --mx-Time_Med: 500px;
-  --mx-Time_Long: 1000px;
+  --mx-Time_Short: 300;
+  --mx-Time_Med: 500;
+  --mx-Time_Long: 1000;
   --mx-Easing_Default: cubic-bezier(.475,.425,0,.995);
   --mx-MediaQuery_Small: 576px;
   --mx-MediaQuery_Med: 768px;

--- a/css/dark.css
+++ b/css/dark.css
@@ -166,9 +166,9 @@
   --mx-Spacing_TagSmallPaddingLeftRight: 8px;
   --mx-Spacing_TextAreaPadding: 12px;
   --mx-Spacing_TooltipPadding: 12px;
-  --mx-Time_Short: 300;
-  --mx-Time_Med: 500;
-  --mx-Time_Long: 1000;
+  --mx-Time_Short: 300ms;
+  --mx-Time_Med: 500ms;
+  --mx-Time_Long: 1000ms;
   --mx-Easing_Default: cubic-bezier(.475,.425,0,.995);
   --mx-MediaQuery_Small: 576px;
   --mx-MediaQuery_Med: 768px;

--- a/css/light.css
+++ b/css/light.css
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (9.0.1)
 **
-** css variables auto-generated on 2021-05-27
+** css variables auto-generated on 2021-05-28
 ** from https://github.com/mxenabled/mx-design-tokens to /css/light.css
 */
 :root {

--- a/css/light.css
+++ b/css/light.css
@@ -172,9 +172,9 @@
   --mx-Spacing_TagSmallPaddingLeftRight: 8px;
   --mx-Spacing_TextAreaPadding: 12px;
   --mx-Spacing_TooltipPadding: 12px;
-  --mx-Time_Short: 300;
-  --mx-Time_Med: 500;
-  --mx-Time_Long: 1000;
+  --mx-Time_Short: 300ms;
+  --mx-Time_Med: 500ms;
+  --mx-Time_Long: 1000ms;
   --mx-Easing_Default: cubic-bezier(.475,.425,0,.995);
   --mx-MediaQuery_Small: 576px;
   --mx-MediaQuery_Med: 768px;

--- a/css/light.css
+++ b/css/light.css
@@ -1,5 +1,5 @@
 /*
-** mx-design-tokens (9.0.0)
+** mx-design-tokens (9.0.1)
 **
 ** css variables auto-generated on 2021-05-27
 ** from https://github.com/mxenabled/mx-design-tokens to /css/light.css
@@ -172,9 +172,9 @@
   --mx-Spacing_TagSmallPaddingLeftRight: 8px;
   --mx-Spacing_TextAreaPadding: 12px;
   --mx-Spacing_TooltipPadding: 12px;
-  --mx-Time_Short: 300px;
-  --mx-Time_Med: 500px;
-  --mx-Time_Long: 1000px;
+  --mx-Time_Short: 300;
+  --mx-Time_Med: 500;
+  --mx-Time_Long: 1000;
   --mx-Easing_Default: cubic-bezier(.475,.425,0,.995);
   --mx-MediaQuery_Small: 576px;
   --mx-MediaQuery_Med: 768px;

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,6 +1,6 @@
 # MX Design Tokens
 
-#### <sup><code>mx-design-tokens (9.0.1)</code> &nbsp; _last generated: 2021-05-27_</sup>
+#### <sup><code>mx-design-tokens (9.0.1)</code> &nbsp; _last generated: 2021-05-28_</sup>
 
 ![light theme](./header_light.png)
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,6 +1,6 @@
 # MX Design Tokens
 
-#### <sup><code>mx-design-tokens (9.0.0)</code> &nbsp; _last generated: 2021-05-27_</sup>
+#### <sup><code>mx-design-tokens (9.0.1)</code> &nbsp; _last generated: 2021-05-27_</sup>
 
 ![light theme](./header_light.png)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-design-tokens",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Design Tokens",
   "main": "dist/index.js",
   "engines": {

--- a/scss/dark.scss
+++ b/scss/dark.scss
@@ -1,5 +1,5 @@
 /*
-** mx-design-tokens (9.0.0)
+** mx-design-tokens (9.0.1)
 **
 ** sass variables auto-generated on 2021-05-27
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/dark.scss
@@ -184,9 +184,9 @@ $Spacing: (
   "TooltipPadding": 12px,
 );
 $Time: (
-  "Short": 300px,
-  "Med": 500px,
-  "Long": 1000px,
+  "Short": 300,
+  "Med": 500,
+  "Long": 1000,
 );
 $Easing: (
   "Default": cubic-bezier(.475,.425,0,.995),

--- a/scss/dark.scss
+++ b/scss/dark.scss
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (9.0.1)
 **
-** sass variables auto-generated on 2021-05-27
+** sass variables auto-generated on 2021-05-28
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/dark.scss
 */
 $Color: (

--- a/scss/dark.scss
+++ b/scss/dark.scss
@@ -184,9 +184,9 @@ $Spacing: (
   "TooltipPadding": 12px,
 );
 $Time: (
-  "Short": 300,
-  "Med": 500,
-  "Long": 1000,
+  "Short": 300ms,
+  "Med": 500ms,
+  "Long": 1000ms,
 );
 $Easing: (
   "Default": cubic-bezier(.475,.425,0,.995),

--- a/scss/light.scss
+++ b/scss/light.scss
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (9.0.1)
 **
-** sass variables auto-generated on 2021-05-27
+** sass variables auto-generated on 2021-05-28
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/light.scss
 */
 $Color: (

--- a/scss/light.scss
+++ b/scss/light.scss
@@ -1,5 +1,5 @@
 /*
-** mx-design-tokens (9.0.0)
+** mx-design-tokens (9.0.1)
 **
 ** sass variables auto-generated on 2021-05-27
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/light.scss
@@ -190,9 +190,9 @@ $Spacing: (
   "TooltipPadding": 12px,
 );
 $Time: (
-  "Short": 300px,
-  "Med": 500px,
-  "Long": 1000px,
+  "Short": 300,
+  "Med": 500,
+  "Long": 1000,
 );
 $Easing: (
   "Default": cubic-bezier(.475,.425,0,.995),

--- a/scss/light.scss
+++ b/scss/light.scss
@@ -190,9 +190,9 @@ $Spacing: (
   "TooltipPadding": 12px,
 );
 $Time: (
-  "Short": 300,
-  "Med": 500,
-  "Long": 1000,
+  "Short": 300ms,
+  "Med": 500ms,
+  "Long": 1000ms,
 );
 $Easing: (
   "Default": cubic-bezier(.475,.425,0,.995),


### PR DESCRIPTION
When generating `css` and `scss` output we sometimes need to add characters before and/or after the token values since the core values are created to work as json objects (which sometimes omit `px` among other things)

This commit makes it so every design token is output exactly the same as json unless explicitly overwritten on a per token basis.