### PR TITLE
[fowles/tooltip] => [master] Remove Boxshadow in Dark Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+.idea/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-.idea/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [10.1.1] - 09-29-2021
+
+### Added
+
+- Added token for the tooltip `boxShadow` to display `'none'` when theme is set to dark.
+
 ## [10.1.0] - 09-07-2021
 
 ### Added

--- a/dist/output/css/dark.css
+++ b/dist/output/css/dark.css
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.1.0)
 **
-** css variables auto-generated on 2021-09-07
+** css variables auto-generated on 2021-09-28
 ** from https://github.com/mxenabled/mx-design-tokens to /css/dark.css
 */
 :root {
@@ -90,7 +90,7 @@
   --mx-BoxShadow_Focus: 0px 0px 0px 2px rgba(82, 138, 224, 0.8);
   --mx-BoxShadow_FocusRingDefault: 0px 0px 0px 2px rgba(82, 138, 224, 0.8);
   --mx-BoxShadow_SelectionBoxShadow: none;
-  --mx-BoxShadow_Tooltip: 0px 6px 12px rgba(106, 115, 129, 0.16), 0px 3px 8px rgba(87, 102, 117, 0.06);
+  --mx-BoxShadow_Tooltip: none;
   --mx-BorderRadius_Small: 2px;
   --mx-BorderRadius_Medium: 4px;
   --mx-BorderRadius_Large: 8px;

--- a/dist/output/css/light.css
+++ b/dist/output/css/light.css
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.1.0)
 **
-** css variables auto-generated on 2021-09-07
+** css variables auto-generated on 2021-09-28
 ** from https://github.com/mxenabled/mx-design-tokens to /css/light.css
 */
 :root {

--- a/dist/output/json/dark.json
+++ b/dist/output/json/dark.json
@@ -95,7 +95,7 @@
     "DropdownMenu": "",
     "Modal": "",
     "SelectionBoxShadow": "none",
-    "Tooltip": "0px 6px 12px rgba(106, 115, 129, 0.16), 0px 3px 8px rgba(87, 102, 117, 0.06)"
+    "Tooltip": "none"
   },
   "BorderRadius": {
     "Small": 2,

--- a/dist/output/md/tokens.md
+++ b/dist/output/md/tokens.md
@@ -1,6 +1,6 @@
 # MX Design Tokens
 
-#### <sup><code>mx-design-tokens (10.1.0)</code> &nbsp; _last generated: 2021-09-07_</sup>
+#### <sup><code>mx-design-tokens (10.1.0)</code> &nbsp; _last generated: 2021-09-28_</sup>
 
 ## 🌞 LIGHT THEME TOKENS
 
@@ -626,7 +626,7 @@
 | DropdownMenu | &nbsp; |
 | Modal | &nbsp; |
 | SelectionBoxShadow | none |
-| Tooltip | 0px 6px 12px rgba(106, 115, 129, 0.16), 0px 3px 8px rgba(87, 102, 117, 0.06) |
+| Tooltip | none |
 
 ---
 

--- a/dist/output/scss/dark.scss
+++ b/dist/output/scss/dark.scss
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.1.0)
 **
-** sass variables auto-generated on 2021-09-07
+** sass variables auto-generated on 2021-09-28
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/dark.scss
 */
 $Color: (
@@ -94,7 +94,7 @@ $BoxShadow: (
   "Focus": "0px 0px 0px 2px rgba(82, 138, 224, 0.8)",
   "FocusRingDefault": "0px 0px 0px 2px rgba(82, 138, 224, 0.8)",
   "SelectionBoxShadow": none,
-  "Tooltip": "0px 6px 12px rgba(106, 115, 129, 0.16), 0px 3px 8px rgba(87, 102, 117, 0.06)",
+  "Tooltip": none,
 );
 $BorderRadius: (
   "Small": 2px,

--- a/dist/output/scss/light.scss
+++ b/dist/output/scss/light.scss
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.1.0)
 **
-** sass variables auto-generated on 2021-09-07
+** sass variables auto-generated on 2021-09-28
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/light.scss
 */
 $Color: (

--- a/dist/tokens/boxShadow.js
+++ b/dist/tokens/boxShadow.js
@@ -54,7 +54,9 @@ var dark = function dark(core) {
     // Modal
     Modal: '',
     // SelectionBox
-    SelectionBoxShadow: 'none'
+    SelectionBoxShadow: 'none',
+    // Tooltip
+    Tooltip: 'none'
   });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "mx-design-tokens",
-  "version": "9.0.0",
+  "version": "10.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "9.0.0",
+      "name": "mx-design-tokens",
+      "version": "10.1.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-design-tokens",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "Design Tokens",
   "main": "dist/index.js",
   "engines": {

--- a/src/tokens/boxShadow.js
+++ b/src/tokens/boxShadow.js
@@ -40,6 +40,8 @@ const dark = (core) => ({
   Modal: '',
   // SelectionBox
   SelectionBoxShadow: 'none',
+  // Tooltip
+  Tooltip: 'none',
 })
 
 export default {


### PR DESCRIPTION
## Description of work

Added `Tooltip: 'none',` to the dark boxShadow design token.

## QA

Used `npm link` to verify there is no longer a shadow on dark, but remains on light.

## Screen Shots

Dark: 
<img width="174" alt="Screen Shot 2021-09-28 at 11 08 35 AM" src="https://user-images.githubusercontent.com/17182194/135133460-b862c1ee-87e6-415b-8e56-cae8f8041c49.png">


Light: 
<img width="154" alt="Screen Shot 2021-09-28 at 11 08 43 AM" src="https://user-images.githubusercontent.com/17182194/135133478-8f014e22-80f6-4e34-b649-eebe5ea0e7ed.png">
