### PR TITLE
[fowles/tooltip-dark-color] => [master] Updated Dark Background for Tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [10.2.2] - 10-15-2021
+
+### Updated
+
+- Updated the dark background for the tooltip to `neutral900`, as per design.
+
 ## [10.2.1] - 10-12-2021
 
 ### Fixed

--- a/dist/mods.js
+++ b/dist/mods.js
@@ -13,6 +13,7 @@ var _index = require("./index");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+// Shared modifications
 var updatedBoxShadow = (0, _utils.updateValues)(_core["default"].BoxShadow, '');
 var updatedEasing = (0, _utils.updateValues)(_core["default"].Easing, {
   x1: 0.475,

--- a/dist/output/css/dark.css
+++ b/dist/output/css/dark.css
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.2.1)
 **
-** css variables auto-generated on 2021-10-12
+** css variables auto-generated on 2021-10-15
 ** from https://github.com/mxenabled/mx-design-tokens to /css/dark.css
 */
 :root {
@@ -313,7 +313,7 @@
   --mx-BackgroundColor_TagWarning: #FFB400;
   --mx-BackgroundColor_TableRowHover: #49505A;
   --mx-BackgroundColor_TableFooter: #49505A;
-  --mx-BackgroundColor_Tooltip: #49505A;
+  --mx-BackgroundColor_Tooltip: #E4E8EE;
   --mx-BackgroundColor_ButtonLinkDestructiveHover: #49505A;
   --mx-BorderColor_Error: #F45532;
   --mx-BorderColor_ButtonLinkHover: #FFFFFF;
@@ -391,6 +391,6 @@
   --mx-TextColor_TagPrimary: #FFFFFF;
   --mx-TextColor_TagSuccess: #FFFFFF;
   --mx-TextColor_TagWarning: #1F2329;
-  --mx-TextColor_Tooltip: #FFFFFF;
+  --mx-TextColor_Tooltip: #121417;
   --mx-TextColor_ButtonLinkDisabled: #6A7381;
 }

--- a/dist/output/css/light.css
+++ b/dist/output/css/light.css
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.2.1)
 **
-** css variables auto-generated on 2021-10-12
+** css variables auto-generated on 2021-10-15
 ** from https://github.com/mxenabled/mx-design-tokens to /css/light.css
 */
 :root {

--- a/dist/output/json/dark.json
+++ b/dist/output/json/dark.json
@@ -344,7 +344,7 @@
     "TagWarning": "#FFB400",
     "TableRowHover": "#49505A",
     "TableFooter": "#49505A",
-    "Tooltip": "#49505A",
+    "Tooltip": "#E4E8EE",
     "ButtonLinkDestructiveHover": "#49505A"
   },
   "BorderColor": {
@@ -426,7 +426,7 @@
     "TagPrimary": "#FFFFFF",
     "TagSuccess": "#FFFFFF",
     "TagWarning": "#1F2329",
-    "Tooltip": "#FFFFFF",
+    "Tooltip": "#121417",
     "ButtonLinkDisabled": "#6A7381"
   }
 }

--- a/dist/output/md/tokens.md
+++ b/dist/output/md/tokens.md
@@ -1,6 +1,6 @@
 # MX Design Tokens
 
-#### <sup><code>mx-design-tokens (10.2.1)</code> &nbsp; _last generated: 2021-10-12_</sup>
+#### <sup><code>mx-design-tokens (10.2.1)</code> &nbsp; _last generated: 2021-10-15_</sup>
 
 ## 🌞 LIGHT THEME TOKENS
 
@@ -940,7 +940,7 @@
 | TagWarning | #FFB400 | [![#FFB400](https://via.placeholder.com/32x16/FFB400/000000?text=+)](https://www.colorhexa.com/FFB400) |
 | TableRowHover | #49505A | [![#49505A](https://via.placeholder.com/32x16/49505A/000000?text=+)](https://www.colorhexa.com/49505A) |
 | TableFooter | #49505A | [![#49505A](https://via.placeholder.com/32x16/49505A/000000?text=+)](https://www.colorhexa.com/49505A) |
-| Tooltip | #49505A | [![#49505A](https://via.placeholder.com/32x16/49505A/000000?text=+)](https://www.colorhexa.com/49505A) |
+| Tooltip | #E4E8EE | [![#E4E8EE](https://via.placeholder.com/32x16/E4E8EE/000000?text=+)](https://www.colorhexa.com/E4E8EE) |
 | ButtonLinkDestructiveHover | #49505A | [![#49505A](https://via.placeholder.com/32x16/49505A/000000?text=+)](https://www.colorhexa.com/49505A) |
 
 ---
@@ -1032,7 +1032,7 @@
 | TagPrimary | #FFFFFF | [![#FFFFFF](https://via.placeholder.com/32x16/FFFFFF/000000?text=+)](https://www.colorhexa.com/FFFFFF) |
 | TagSuccess | #FFFFFF | [![#FFFFFF](https://via.placeholder.com/32x16/FFFFFF/000000?text=+)](https://www.colorhexa.com/FFFFFF) |
 | TagWarning | #1F2329 | [![#1F2329](https://via.placeholder.com/32x16/1F2329/000000?text=+)](https://www.colorhexa.com/1F2329) |
-| Tooltip | #FFFFFF | [![#FFFFFF](https://via.placeholder.com/32x16/FFFFFF/000000?text=+)](https://www.colorhexa.com/FFFFFF) |
+| Tooltip | #121417 | [![#121417](https://via.placeholder.com/32x16/121417/000000?text=+)](https://www.colorhexa.com/121417) |
 | ButtonLinkDisabled | #6A7381 | [![#6A7381](https://via.placeholder.com/32x16/6A7381/000000?text=+)](https://www.colorhexa.com/6A7381) |
 
 ---

--- a/dist/output/scss/dark.scss
+++ b/dist/output/scss/dark.scss
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.2.1)
 **
-** sass variables auto-generated on 2021-10-12
+** sass variables auto-generated on 2021-10-15
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/dark.scss
 */
 $Color: (
@@ -341,7 +341,7 @@ $BackgroundColor: (
   "TagWarning": #FFB400,
   "TableRowHover": #49505A,
   "TableFooter": #49505A,
-  "Tooltip": #49505A,
+  "Tooltip": #E4E8EE,
   "ButtonLinkDestructiveHover": #49505A,
 );
 $BorderColor: (
@@ -423,6 +423,6 @@ $TextColor: (
   "TagPrimary": #FFFFFF,
   "TagSuccess": #FFFFFF,
   "TagWarning": #1F2329,
-  "Tooltip": #FFFFFF,
+  "Tooltip": #121417,
   "ButtonLinkDisabled": #6A7381,
 );

--- a/dist/output/scss/light.scss
+++ b/dist/output/scss/light.scss
@@ -1,7 +1,7 @@
 /*
 ** mx-design-tokens (10.2.1)
 **
-** sass variables auto-generated on 2021-10-12
+** sass variables auto-generated on 2021-10-15
 ** from https://github.com/mxenabled/mx-design-tokens to /scss/light.scss
 */
 $Color: (

--- a/dist/tokens/backgroundColor.js
+++ b/dist/tokens/backgroundColor.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -128,7 +128,7 @@ var light = function light(core) {
 };
 
 var dark = function dark(core) {
-  return _objectSpread({}, light(core), {
+  return _objectSpread(_objectSpread({}, light(core)), {}, {
     // Global
     Body: core.Color.Neutral900,
     Error: core.Color.Error200,
@@ -234,7 +234,7 @@ var dark = function dark(core) {
     TableRowHover: core.Color.Neutral700,
     TableFooter: core.Color.Neutral700,
     // Tooltip
-    Tooltip: core.Color.Neutral700
+    Tooltip: core.Color.Neutral300
   });
 };
 

--- a/dist/tokens/borderColor.js
+++ b/dist/tokens/borderColor.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -60,7 +60,7 @@ var light = function light(core) {
 };
 
 var dark = function dark(core) {
-  return _objectSpread({}, light(core), {
+  return _objectSpread(_objectSpread({}, light(core)), {}, {
     // Global
     Error: core.Color.Error200,
     // Button

--- a/dist/tokens/borderRadius.js
+++ b/dist/tokens/borderRadius.js
@@ -5,14 +5,14 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var light = function light(core) {
-  return _objectSpread({}, core.BorderRadius, {
+  return _objectSpread(_objectSpread({}, core.BorderRadius), {}, {
     // Button
     Button: core.BorderRadius.Medium,
     // Card

--- a/dist/tokens/boxShadow.js
+++ b/dist/tokens/boxShadow.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -40,7 +40,7 @@ var light = function light(core) {
 };
 
 var dark = function dark(core) {
-  return _objectSpread({}, light(core), {
+  return _objectSpread(_objectSpread({}, light(core)), {}, {
     // Bottom Bar
     BottomBar: '',
     // Card

--- a/dist/tokens/fontFamily.js
+++ b/dist/tokens/fontFamily.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/dist/tokens/fontSize.js
+++ b/dist/tokens/fontSize.js
@@ -5,14 +5,14 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var light = function light(core) {
-  return _objectSpread({}, core.FontSize, {
+  return _objectSpread(_objectSpread({}, core.FontSize), {}, {
     // Breadcrumbs
     Breadcrumbs: core.FontSize.Small,
     // Button

--- a/dist/tokens/letterSpacing.js
+++ b/dist/tokens/letterSpacing.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/dist/tokens/spacing.js
+++ b/dist/tokens/spacing.js
@@ -5,14 +5,14 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var light = function light(core) {
-  return _objectSpread({}, core.Spacing, {
+  return _objectSpread(_objectSpread({}, core.Spacing), {}, {
     // Breadcrumbs
     BreadcrumbsDividerMargin: core.Spacing.Small,
     // Button

--- a/dist/tokens/textColor.js
+++ b/dist/tokens/textColor.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -75,7 +75,7 @@ var light = function light(core) {
 };
 
 var dark = function dark(core) {
-  return _objectSpread({}, light(core), {
+  return _objectSpread(_objectSpread({}, light(core)), {}, {
     // Global
     Active: core.Color.Brand200,
     ActiveHover: core.Color.Brand100,
@@ -128,7 +128,9 @@ var dark = function dark(core) {
     TagNeutral: core.Color.NeutralWhite,
     TagPrimary: core.Color.NeutralWhite,
     TagSuccess: core.Color.NeutralWhite,
-    TagWarning: core.Color.Neutral800
+    TagWarning: core.Color.Neutral800,
+    // Tooltip
+    Tooltip: core.Color.Neutral900
   });
 };
 

--- a/dist/tokens/zIndex.js
+++ b/dist/tokens/zIndex.js
@@ -5,9 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -5,17 +5,21 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.updateValues = exports.removeSuffix = exports.addSuffix = exports.splitTokens = exports.collapseTokens = exports.expandTokens = exports.getTokenType = exports.deepMerge = exports.isObject = void 0;
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 // test if value is a simple object {}
 var isObject = function isObject(value) {

--- a/src/tokens/backgroundColor.js
+++ b/src/tokens/backgroundColor.js
@@ -219,7 +219,7 @@ const dark = (core) => ({
   TableRowHover: core.Color.Neutral700,
   TableFooter: core.Color.Neutral700,
   // Tooltip
-  Tooltip: core.Color.Neutral700,
+  Tooltip: core.Color.Neutral300,
 })
 
 export default {

--- a/src/tokens/textColor.js
+++ b/src/tokens/textColor.js
@@ -114,6 +114,8 @@ const dark = (core) => ({
   TagPrimary: core.Color.NeutralWhite,
   TagSuccess: core.Color.NeutralWhite,
   TagWarning: core.Color.Neutral800,
+  // Tooltip
+  Tooltip: core.Color.Neutral900,
 })
 
 export default {


### PR DESCRIPTION
## Description of work

When QA-ing the tooltip we found that the dark mode background color for the tooltip was a bit washed out. Brian reviewed and we've updated the tooltip dark to:

Background Color: `neutral300` 
Text Color: `neutral900`
## QA

Used `npm link` to verify the new dark mode color.

## Screen Shots

## Description of work

Added `Tooltip: 'none',` to the dark boxShadow design token.

## QA

Used `npm link` to verify there is no longer a shadow on dark, but remains on light.

## Screen Shots

Dark: 

![CleanShot 2021-10-15 at 12 56 56](https://user-images.githubusercontent.com/17182194/137539588-fa1c4629-2763-4e2a-bc2d-e7943fb68ef2.png)


